### PR TITLE
Disable CKEditor "AllowedContent" filter

### DIFF
--- a/src/main/resources/templates/admin/pageform.html
+++ b/src/main/resources/templates/admin/pageform.html
@@ -78,7 +78,8 @@
 	<script type="text/javascript">
 		$(document).ready(function() {
 			CKEDITOR.replace("content", {
-				extraPlugins : "autogrow"
+				extraPlugins : "autogrow",
+				allowedContent : true
 			});
 		});
 	</script>


### PR DESCRIPTION
This will allow the use of any HTML tag in the content. In particular, it will enable the use of iframe tag for embedding content (prime example would be facebook photo galleries). This change is untested but should work.